### PR TITLE
Add initial prompt

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ name: Create and publish a Docker image
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
   push:
-    branches: ['release']
+    branches: ['release', 'latest']
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ name: Create and publish a Docker image
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
   push:
-    branches: ['release', 'latest']
+    branches: ['release']
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,6 +38,7 @@ services:
       WHISPER_BEAM_SIZE: "5"
       WHISPER_HTTP_HOST: "127.0.0.1"  # keep internal
       WHISPER_HTTP_PORT: "8910"
+      WHISPER_INITIAL_PROMPT: "glossary" # Description of audio that can help Whisper transcribe unusual words better
 
       # Wyoming bind address/port
       WYOMING_URI: "tcp://0.0.0.0:7891"

--- a/start.sh
+++ b/start.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 : "${WHISPER_HTTP_PORT:=8910}"
 : "${WYOMING_URI:=tcp://0.0.0.0:7891}"
 : "${MODEL_BASE_URL:=https://huggingface.co/ggerganov/whisper.cpp/resolve/main}"
+: "${WHISPER_INITIAL_PROMPT:=}"
 
 MODELS_DIR=/models
 MODEL_FILE="ggml-${WHISPER_MODEL}.bin"
@@ -34,6 +35,7 @@ export LD_LIBRARY_PATH="/opt/intel/oneapi/compiler/latest/lib:/opt/intel/oneapi/
   --port "${WHISPER_HTTP_PORT}" \
   -l "${WHISPER_LANG}" \
   -bs "${WHISPER_BEAM_SIZE}" \
+  --initial-prompt "${WHISPER_INITIAL_PROMPT}" \
   --suppress-nst &
 WHISPER_PID=$!
 

--- a/start.sh
+++ b/start.sh
@@ -35,7 +35,7 @@ export LD_LIBRARY_PATH="/opt/intel/oneapi/compiler/latest/lib:/opt/intel/oneapi/
   --port "${WHISPER_HTTP_PORT}" \
   -l "${WHISPER_LANG}" \
   -bs "${WHISPER_BEAM_SIZE}" \
-  --initial-prompt "${WHISPER_INITIAL_PROMPT}" \
+  --prompt "${WHISPER_INITIAL_PROMPT}" \
   --suppress-nst &
 WHISPER_PID=$!
 


### PR DESCRIPTION
Thank you for your repo.  It was exactly what I was looking for to run Whisper on my Intel machine with GPU access.  I came across from the Whisper app on Home Assistant.  That had an 'initial prompt', which was great for adding a glossary to the speech to text and improving accuracy.  I have added that to this.  I've tested and its working.